### PR TITLE
add filtering by availability

### DIFF
--- a/api/products/models.py
+++ b/api/products/models.py
@@ -1,10 +1,12 @@
 import logging
+from typing import Literal
 from django.conf import settings
 from django.db import models
 from accounts.models import User
 from stores.models import Store
 from django.core.exceptions import ValidationError
 from django.utils.timezone import now
+from django.db.models import Q, Count, F
 
 
 class Category(models.Model):
@@ -33,6 +35,82 @@ class ProductQuerySet(models.QuerySet):
 
     def dead(self):
         return self.filter(is_deleted=True)
+
+    def available(self):
+        # Products that do not have sizes and have available_quantity > 0
+        no_size_available = Q(
+            has_sizes=False,
+            available_quantity__gt=0
+        )
+
+        # Products with sizes: All non-deleted sizes have available_quantity > 0
+        with_sizes_available = Q(has_sizes=True) & ~Q(
+            id__in=Product.objects.filter(
+                has_sizes=True
+            ).annotate(
+                unavailable_sizes=Count(
+                    'sizes',
+                    filter=Q(sizes__is_deleted=False,
+                             sizes__available_quantity__lte=0)
+                )
+            ).filter(unavailable_sizes__gt=0).values_list("id", flat=True)
+        )
+
+        return self.filter(no_size_available | with_sizes_available)
+
+    def unavailable(self):
+        # Products that do not have sizes and have available_quantity <= 0
+        no_size_unavailable = Q(
+            has_sizes=False,
+            available_quantity__lte=0
+        )
+
+        # Products with sizes: All non-deleted sizes have available_quantity <= 0
+        with_sizes_unavailable = Q(
+            id__in=Product.objects.filter(
+                has_sizes=True
+            ).annotate(
+                total_active_sizes=Count(
+                    'sizes',
+                    filter=Q(sizes__is_deleted=False)
+                ),
+                sizes_with_stock=Count(
+                    'sizes',
+                    filter=Q(sizes__is_deleted=False,
+                             sizes__available_quantity__gt=0)
+                ),
+            ).filter(
+                total_active_sizes__gt=0,
+                sizes_with_stock=0
+            ).values_list('id', flat=True)
+        )
+
+        return self.filter(no_size_unavailable | with_sizes_unavailable)
+
+    def partially_available(self):
+        # Products with sizes
+        return self.filter(
+            id__in=Product.objects.filter(
+                has_sizes=True
+            ).annotate(
+                total_active_sizes=Count(
+                    'sizes',
+                    filter=Q(sizes__is_deleted=False)
+                ),
+                sizes_with_stock=Count(
+                    'sizes',
+                    filter=Q(sizes__is_deleted=False,
+                             sizes__available_quantity__gt=0)
+                ),
+            ).filter(
+                total_active_sizes__gt=0,
+            ).exclude(
+                sizes_with_stock=0  # exclude products with all sizes unavailable
+            ).exclude(
+                # exclude products with all sizes available
+                sizes_with_stock=F('total_active_sizes')
+            ).values_list('id', flat=True)
+        )
 
 
 class Product(models.Model):
@@ -128,6 +206,21 @@ class Product(models.Model):
     @property
     def store_location(self):
         return self.store.location
+
+    @property
+    def availability(self) -> Literal["available", "unavailable", "partially_available"]:
+        if self.has_sizes:
+            sizes = self.sizes.all()
+            if not sizes.exists():
+                return "unavailable"  # No sizes defined
+            available_counts = [size.available_quantity > 0 for size in sizes]
+            if all(available_counts):
+                return "available"
+            elif any(available_counts):
+                return "partially_available"
+            return "unavailable"
+        else:
+            return "available" if (self.available_quantity or 0) > 0 else "unavailable"
 
     def clean(self):
         if self.has_sizes:

--- a/api/products/serializers.py
+++ b/api/products/serializers.py
@@ -114,7 +114,8 @@ class ProductSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
             "offer",
-            "classification"
+            "classification",
+            "availability",
         ]
         read_only_fields = [
             "id",
@@ -125,7 +126,8 @@ class ProductSerializer(serializers.ModelSerializer):
             "reserved_quantity",
             'current_price',
             'is_deleted',
-            "offer"
+            "offer",
+            "availability",
         ]
         extra_kwargs = {
             "product_name": {"required": True},

--- a/api/products/tests/test_helpers.py
+++ b/api/products/tests/test_helpers.py
@@ -156,6 +156,30 @@ class TestHelpers:
         return product_data
 
     @staticmethod
+    def get_available_sizes():
+        return [
+            {"size": "S", "available_quantity": 10},
+            {"size": "M", "available_quantity": 12},
+            {"size": "L", "available_quantity": 4},
+        ]
+
+    @staticmethod
+    def get_paritally_available_sizes():
+        return [
+            {"size": "S", "available_quantity": 10},
+            {"size": "M", "available_quantity": 0},
+            {"size": "L", "available_quantity": 4},
+        ]
+
+    @staticmethod
+    def get_unavailable_sizes():
+        return [
+            {"size": "S", "available_quantity": 0},
+            {"size": "M", "available_quantity": 0},
+            {"size": "L", "available_quantity": 0},
+        ]
+
+    @staticmethod
     def creat_product(product_data, owner, store):
         """
         Helper to create a product instance along with optional sizes and offer.

--- a/api/products/tests/test_models.py
+++ b/api/products/tests/test_models.py
@@ -159,7 +159,7 @@ class ProductAvailabilityTests(TestCase):
         )
         self.available_product_with_deleted_size = TestHelpers.creat_product(
             TestHelpers.get_valid_product_data_with_size(
-                TestHelpers.get_available_sizes()
+                sizes=TestHelpers.get_available_sizes()
             ),
             self.user,
             self.store

--- a/api/products/tests/test_models.py
+++ b/api/products/tests/test_models.py
@@ -1,6 +1,6 @@
 import logging
 from django.test import TestCase
-from products.models import Size
+from products.models import Product, Size
 from products.tests.test_helpers import TestHelpers
 
 logger = logging.getLogger('products_tests')
@@ -119,3 +119,96 @@ class ProductSizeSoftDeleteTests(TestCase):
         self.assertIn("L", returned_sizes)
 
         logger.info("product.sizes.all() excludes deleted sizes test passed.")
+
+
+class ProductAvailabilityTests(TestCase):
+    def setUp(self):
+        self.user, self.store, self.buisness_owner = TestHelpers.create_seller()
+        self.available_product_with_sizes = TestHelpers.creat_product(
+            TestHelpers.get_valid_product_data_with_size(
+                sizes=TestHelpers.get_available_sizes()
+            ),
+            self.user,
+            self.store,
+        )
+        self.unavailable_product_with_sizes = TestHelpers.creat_product(
+            TestHelpers.get_valid_product_data_with_size(
+                sizes=TestHelpers.get_unavailable_sizes()
+            ),
+            self.user,
+            self.store,
+        )
+        self.paritally_available_product_with_sizes = TestHelpers.creat_product(
+            TestHelpers.get_valid_product_data_with_size(
+                sizes=TestHelpers.get_paritally_available_sizes()
+            ),
+            self.user,
+            self.store,
+        )
+        self.available_product_without_sizes = TestHelpers.creat_product(
+            TestHelpers.get_valid_product_data_without_sizes(
+                available_quantity=10),
+            self.user,
+            self.store,
+        )
+        self.unavailable_product_without_sizes = TestHelpers.creat_product(
+            TestHelpers.get_valid_product_data_without_sizes(
+                available_quantity=0),
+            self.user,
+            self.store,
+        )
+        self.available_product_with_deleted_size = TestHelpers.creat_product(
+            TestHelpers.get_valid_product_data_with_size(
+                TestHelpers.get_available_sizes()
+            ),
+            self.user,
+            self.store
+        )
+        deleted_size = self.available_product_with_deleted_size.sizes.first()
+        deleted_size.available_quantity = 0
+        deleted_size.save()
+        deleted_size.delete()
+        return super().setUp()
+
+    def test_availability_property(self):
+        self.assertEqual(
+            self.available_product_with_sizes.availability, "available")
+        self.assertEqual(
+            self.unavailable_product_with_sizes.availability, "unavailable")
+        self.assertEqual(
+            self.paritally_available_product_with_sizes.availability, "partially_available")
+        self.assertEqual(
+            self.available_product_without_sizes.availability, "available")
+        self.assertEqual(
+            self.unavailable_product_without_sizes.availability, "unavailable")
+        self.assertEqual(
+            self.available_product_with_deleted_size.availability, "available")
+
+    def test_available_filter(self):
+        available = Product.objects.available()
+        self.assertIn(self.available_product_with_sizes, available)
+        self.assertIn(self.available_product_without_sizes, available)
+        self.assertIn(self.available_product_with_deleted_size, available)
+        self.assertNotIn(self.unavailable_product_with_sizes, available)
+        self.assertNotIn(
+            self.paritally_available_product_with_sizes, available)
+        self.assertNotIn(self.unavailable_product_without_sizes, available)
+
+    def test_unavailable_filter(self):
+        unavailable = Product.objects.unavailable()
+        self.assertIn(self.unavailable_product_with_sizes, unavailable)
+        self.assertIn(self.unavailable_product_without_sizes, unavailable)
+        self.assertNotIn(self.available_product_with_deleted_size, unavailable)
+        self.assertNotIn(self.available_product_with_sizes, unavailable)
+        self.assertNotIn(self.available_product_without_sizes, unavailable)
+        self.assertNotIn(
+            self.paritally_available_product_with_sizes, unavailable)
+
+    def test_partially_available_filter(self):
+        partial = Product.objects.partially_available()
+        self.assertIn(self.paritally_available_product_with_sizes, partial)
+        self.assertNotIn(self.available_product_with_sizes, partial)
+        self.assertNotIn(self.available_product_with_deleted_size, partial)
+        self.assertNotIn(self.unavailable_product_with_sizes, partial)
+        self.assertNotIn(self.unavailable_product_without_sizes, partial)
+        self.assertNotIn(self.available_product_without_sizes, partial)


### PR DESCRIPTION
## 🔄 Filter My Products by Availability  
### 📌 Summary  
This PR adds support for filtering products returned from the `my-products` and `products` endpoints by availability status.

### ✅ Changes Made  
- Added support for `availability` query parameter.
- Allowed repeated keys for multiple values (e.g. `?availability=available&availability=partially_available`).
- Added unit tests to validate filtering and ownership constraints.

### 🧪 Tests
- Ensures only the current seller’s products are returned in my products.
- Verifies that filtering by one or more availability values returns correct results.

### 💡 Notes  
- `availability` accepts repeated query params rather than a comma-separated string.
- Allowed values include: `available`, `partially_available`, and `unavailable`.
@Mohamed-SE23 
Closes #78 