### PR TITLE
Feature/simplejwt cookie overrides

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -630,7 +630,7 @@ SPECTACULAR_SETTINGS = {
 
 # Simple JWT settings
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=1),  # Adjust as needed
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=15),  # Adjust as needed
     'REFRESH_TOKEN_LIFETIME': timedelta(days=7),
     'ROTATE_REFRESH_TOKENS': True,
     'BLACKLIST_AFTER_ROTATION': True,  # requires blacklist app

--- a/api/api/urls.py
+++ b/api/api/urls.py
@@ -26,10 +26,12 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
     SpectacularRedocView
 )
+from authentication.views import CookieTokenObtainPairView
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/v1/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('api/v1/token/', CookieTokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/v1/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/v1/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
     path('api/v1/schema/', SpectacularAPIView.as_view(), name='schema'),

--- a/api/api/urls.py
+++ b/api/api/urls.py
@@ -26,13 +26,13 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
     SpectacularRedocView
 )
-from authentication.views import CookieTokenObtainPairView
+from authentication.views import CookieTokenObtainPairView, CookieTokenRefreshView
 
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/token/', CookieTokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('api/v1/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('api/v1/token/refresh/', CookieTokenRefreshView.as_view(), name='token_refresh'),
     path('api/v1/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
     path('api/v1/schema/', SpectacularAPIView.as_view(), name='schema'),
     path('api/v1/docs/swagger/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),

--- a/api/authentication/views.py
+++ b/api/authentication/views.py
@@ -878,6 +878,50 @@ class CookieTokenObtainPairView(TokenObtainPairView):
         return response
 
 
+@extend_schema(
+    summary="Obtain JWT Token Pair (access in body, refresh in HttpOnly cookie)",
+    description=(
+        "Authenticates a user and returns an access token in the response body. "
+        "The refresh token is set as a secure, HttpOnly cookie named `refresh_token`."
+    ),
+    request=TokenObtainPairSerializer,
+    responses={
+        200: OpenApiResponse(
+            description="Access token in response body. Refresh token in HttpOnly cookie.",
+            examples=[
+                OpenApiExample(
+                    "Success",
+                    value={"access": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."},
+                    response_only=True,
+                )
+            ]
+        ),
+        401: OpenApiResponse(description="Invalid credentials."),
+    },
+)
+
+
+@extend_schema(
+    summary="Refresh JWT Access Token (refresh from HttpOnly cookie)",
+    description=(
+        "Refreshes the access token. The refresh token is read from the `refresh_token` HttpOnly cookie "
+        "if not provided in the request body."
+    ),
+    request=None,
+    responses={
+        200: OpenApiResponse(
+            description="Returns a new access token.",
+            examples=[
+                OpenApiExample(
+                    "Success",
+                    value={"access": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."},
+                    response_only=True,
+                )
+            ]
+        ),
+        401: OpenApiResponse(description="Invalid or expired refresh token."),
+    },
+)
 class CookieTokenRefreshView(TokenRefreshView):
     """
     A custom view that extends TokenRefreshView to support retrieving the refresh token from an HTTP cookie.

--- a/api/authentication/views.py
+++ b/api/authentication/views.py
@@ -4,7 +4,7 @@ from rest_framework import status # type: ignore
 from rest_framework.exceptions import ValidationError
 from rest_framework_simplejwt.tokens import RefreshToken # type: ignore
 from rest_framework.response import Response # type: ignore
-from rest_framework_simplejwt.views import TokenObtainPairView
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from rest_framework.views import APIView
 from rest_framework.permissions import AllowAny, IsAuthenticated # type: ignore
@@ -876,3 +876,18 @@ class CookieTokenObtainPairView(TokenObtainPairView):
                 max_age=7*24*60*60,  # 1 week, adjust as needed
             )
         return response
+
+
+class CookieTokenRefreshView(TokenRefreshView):
+    """
+    A custom view that extends TokenRefreshView to support retrieving the refresh token from an HTTP cookie.
+    If the "refresh" token is not present in the request body, this view attempts to extract it from the "refresh_token" cookie.
+    This allows clients to perform token refresh operations using cookies for enhanced security and convenience.
+    Methods:
+        post(request, *args, **kwargs): Handles POST requests to refresh JWT tokens, checking both request data and cookies for the refresh token.
+    """
+    def post(self, request, *args, **kwargs):
+        # Get refresh token from cookie if not in body
+        if "refresh" not in request.data:
+            request.data["refresh"] = request.COOKIES.get("refresh_token")
+        return super().post(request, *args, **kwargs)


### PR DESCRIPTION
This pull request enhances the security and usability of JWT authentication in the API by switching to cookie-based handling of refresh tokens. The main changes include introducing custom views to store the refresh token in a secure, HttpOnly cookie (instead of the response body), updating URL routing to use these views, and extending token lifetimes for improved user experience.

**Authentication and Token Handling Improvements:**

* Added `CookieTokenObtainPairView` and `CookieTokenRefreshView` in `authentication/views.py` to set the refresh token as a secure, HttpOnly cookie, and to allow refreshing tokens using the cookie if not provided in the request body. These views also provide improved OpenAPI documentation.
* Updated `api/urls.py` to use the new cookie-based token obtain and refresh views in place of the default JWT views.
* Modified the way the refresh token cookie is set to always use `secure=True` and explicitly set `max_age` to 1 week for better security and consistency.

**Token Lifetime Configuration:**

* Increased the JWT access token lifetime from 1 minute to 15 minutes in `settings.py` to reduce the frequency of required token refreshes.