### PR TITLE
Feature/reset password flow otp secure

### DIFF
--- a/api/accounts/signals.py
+++ b/api/accounts/signals.py
@@ -42,11 +42,11 @@ def user_created_handler(sender, instance, created, **kwargs):
                 email_host_password=settings.EMAIL_HOST_PASSWORD_NO_REPLY,
                 from_email=settings.EMAIL_HOST_USER_NO_REPLY
             )
-    # After sending the welcome email:
-    send_activation_email_task.apply_async(
-        args=[instance.id],
-        countdown=60
-    )  # 60 seconds delay
+        # After sending the welcome email:
+        send_activation_email_task.apply_async(
+            args=[instance.id],
+            countdown=60
+        )  # 60 seconds delay
 
 
 @receiver(post_save, sender=BusinessOwner)
@@ -73,8 +73,8 @@ def business_owner_created_handler(sender, instance, created, **kwargs):
             email_host_password=settings.EMAIL_HOST_PASSWORD_NO_REPLY,
             from_email=settings.EMAIL_HOST_USER_NO_REPLY
         )
-    # After sending the welcome email:
-    send_activation_email_task.apply_async(
-        args=[instance.id],
-        countdown=60
-    )  # 60 seconds delay
+        # After sending the welcome email:
+        send_activation_email_task.apply_async(
+            args=[instance.id],
+            countdown=60
+        )  # 60 seconds delay


### PR DESCRIPTION
## Fix: Prevent Multiple Activation Emails on Password Reset and User Updates

### **Summary**
This PR updates the signal handlers for user and business owner creation to ensure activation emails are sent **only once**—when a new user or business owner is registered.  
Previously, activation emails were triggered on every user update (including password resets), resulting in multiple unwanted emails.

---

### **Changes**

- **User Creation Signal (`user_created_handler`):**
  - Activation email and welcome email are now sent **only if `created` is `True`** (i.e., on new user registration).
  - No activation email is sent on user updates (e.g., password reset, profile changes).
  - Welcome email is sent only to non-business owners.

- **Business Owner Creation Signal (`business_owner_created_handler`):**
  - Welcome and activation emails are sent only when a new `BusinessOwner` is created.

---

### **Impact**

- **Fixes bug** where users received multiple activation emails during password reset or other updates.
- **Improves user experience** and reduces email spam.
- **Follows best practices** for signal usage in Django.

---

### **Testing**

- Register a new user: activation and welcome emails are sent once.
- Register a new business owner: business welcome and activation emails are sent once.
- Update user (e.g., password reset): **no activation email is sent**.

---

### **Closes**

- Resolves unwanted activation emails on password reset.